### PR TITLE
Fetch tweets replace current list of tweets

### DIFF
--- a/frontend/src/reducers/tweet_reducer.js
+++ b/frontend/src/reducers/tweet_reducer.js
@@ -8,10 +8,11 @@ export default function(oldState = {}, action){
 
   switch(action.type){
     case RECEIVE_TWEETS:
+      let cleanState = {};
       Object.values(action.tweets).forEach(tweet => {
-        newState[tweet.id] = tweet;
+        cleanState[tweet.id] = tweet;
       });
-      return newState;
+      return cleanState;
 
     default:
       return oldState;


### PR DESCRIPTION
Fetch tweets replace current list of tweets instead of update current list so that new filtered tweets will be shown.