### PR TITLE
Fix tweet remove to only remove one tweet

### DIFF
--- a/frontend/src/reducers/workspace_reducer.js
+++ b/frontend/src/reducers/workspace_reducer.js
@@ -43,12 +43,6 @@ export default function(oldState = {}, action){
             newState[action.id].comments = commentCopy;
             return newState;
 
-        case REMOVE_TWEET_FROM_FOLDER:
-            let newFolders = [...newState[action.workspaceId].folders];
-            newFolders[action.folder_idx].tweets.splice(action.tweetIdx, 1);
-            newState[action.workspaceId].folders = newFolders;
-            return newState;
-
         case RECEIVE_USER_LOGOUT:
             return {};
 


### PR DESCRIPTION
The reducer for the folder modal and workspaces both had functionality
to remove tweets from their respective tweets arrays. However, these
tweet arrays were not copies of each other which resulted in two tweets
being removed one after another. The functionality to remove tweets from
workspaces was therefore deleted since that was already being done in
the modal reducer.